### PR TITLE
Fix date handling in model, controller, and routes

### DIFF
--- a/server/src/controllers/__tests__/map.spec.ts
+++ b/server/src/controllers/__tests__/map.spec.ts
@@ -33,7 +33,10 @@ jest.mock("../../db/index", () => {
 describe("MapController", () => {
   describe("getMap", () => {
     it("should get a map", async () => {
-      const mockMap = { id: 1, day: new Date(), par: 3, hole_x: 1, hole_y: 1, ball_x: 1, ball_y: 1 }
+      const date = new Date()
+      date.setUTCHours(0, 0, 0, 0)
+      console.log(date)
+      const mockMap = { id: 1, day: date, par: 3, hole_x: 1, hole_y: 1, ball_x: 1, ball_y: 1 }
       const mockSandtraps = [{ id: 1, mapId: 1, x: 1, y: 1 }]
       const mockWater = [{ id: 1, mapId: 1, x: 1, y: 1 }]
       const mockBarriers = [{ id: 1, mapId: 1, x: 1, y: 1 }]
@@ -49,7 +52,7 @@ describe("MapController", () => {
       ;(database.Water.findAll as jest.Mock).mockResolvedValue(mockWater)
       ;(database.Barrier.findAll as jest.Mock).mockResolvedValue(mockBarriers)
 
-      const fullMap: FullMap | null = await MapController.getMap(new Date())
+      const fullMap: FullMap | null = await MapController.getMap(date)
 
       expect(database.Map.findOne).toHaveBeenCalledWith({ where: { day: mockMap.day } })
       expect(database.Sandtrap.findAll).toHaveBeenCalledWith({ where: { mapId: 1 } })

--- a/server/src/models/map.ts
+++ b/server/src/models/map.ts
@@ -23,7 +23,7 @@ export class Map extends Model<Map> {
 
   @AllowNull(false)
   @Index("day-index")
-  @Column(DataType.DATEONLY)
+  @Column(DataType.DATE)
   day!: Date
 
   @AllowNull(false)

--- a/server/src/routes/map.ts
+++ b/server/src/routes/map.ts
@@ -7,7 +7,7 @@ const mapRouter = Router()
 mapRouter.get("/", async (req, res) => {
   try {
     const today = new Date()
-    console.log(today)
+    today.setUTCHours(0, 0, 0, 0)
     const mapExists: FullMap | null = await MapController.getMap(today)
 
     if (mapExists) {


### PR DESCRIPTION
## Description
Change map model to use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) full format instead of date only

## Motivation and Context
This change is because Date objects in typescript will always be in YYYY-MM-DDTHH:MM:SS.SSSZ format

We could convert it to string format (YYYY-MM-DD) but that defeats the purpose of restricting DB to only accepting Dates

When comparing Dates we just need to convert the hours, minutes, and seconds to 0 so we just compare the date

This fixes the issue of testing dates differing by seconds

## How Has This Been Tested?
Tested in pgAdmin with Postman
Tested in controllers (screenshot below to show new date format)

## Artifacts (if appropriate):


https://github.com/zdigness/puttdle/assets/60762808/479c72ab-6f95-4965-9b94-5a90834c0bac

![Screenshot 2024-04-17](https://github.com/zdigness/puttdle/assets/60762808/6890d5df-35b0-4b71-80f2-859dacf90c0d)

