### PR TITLE
[TASK] Update User and Score tables

### DIFF
--- a/server/src/controllers/__tests__/user.spec.ts
+++ b/server/src/controllers/__tests__/user.spec.ts
@@ -63,18 +63,18 @@ describe("UserController", () => {
   })
 
   it("should create a user", async () => {
-    const mockUser: [{ id: number; email: string }, boolean] = [{ id: 1, email: "test@test.com" }, true]
-    const mockScore: [{ userId: number; score: number }, boolean] = [{ userId: 1, score: 0 }, true]
-    const expectedFullUser = { user: mockUser[0], scores: mockScore[0] }
+    const mockUser: [{ id: number; email: string; streak: 0 }, boolean] = [
+      { id: 1, email: "test@test.com", streak: 0 },
+      true,
+    ]
+    const expectedUser = mockUser[0]
 
     ;(database.User.findOrCreate as jest.Mock).mockResolvedValue(mockUser)
-    ;(database.Score.findOrCreate as jest.Mock).mockResolvedValue(mockScore)
 
     const fullUser = await UserController.createUser("test@test.com")
 
     expect(database.User.findOrCreate).toHaveBeenCalledWith({ where: { email: "test@test.com" } })
-    expect(database.Score.findOrCreate).toHaveBeenCalledWith({ where: { userId: mockUser[0].id } })
-    expect(fullUser).toEqual(expectedFullUser)
+    expect(fullUser).toEqual(expectedUser)
   })
 
   it("should not create a user because they already exist", async () => {
@@ -104,8 +104,10 @@ describe("UserController", () => {
   })
 
   it("should get a user", async () => {
-    const mockUser = { id: 1, email: "test@test.com" }
-    const mockScore = { userId: 1, score: 0 }
+    const date = new Date()
+    date.setUTCHours(0, 0, 0, 0)
+    const mockUser = { id: 1, email: "test@test.com", streak: 1 }
+    const mockScore = { userId: 1, score: 2, day: date }
     const expectedFullUser = { user: mockUser, scores: mockScore }
 
     ;(database.User.findOne as jest.Mock).mockResolvedValue(mockUser)
@@ -114,7 +116,7 @@ describe("UserController", () => {
     const fullUser = await UserController.getUser(mockUser.email)
 
     expect(database.User.findOne).toHaveBeenCalledWith({ where: { email: mockUser.email } })
-    expect(database.Score.findOne).toHaveBeenCalledWith({ where: { userId: mockUser.id } })
+    expect(database.Score.findOne).toHaveBeenCalledWith({ where: { userId: mockUser.id, day: date } })
     expect(fullUser).toEqual(expectedFullUser)
   })
 
@@ -131,6 +133,8 @@ describe("UserController", () => {
   })
 
   it("should return null when getting a user that exists but does not have a score", async () => {
+    const date = new Date()
+    date.setUTCHours(0, 0, 0, 0)
     const mockUser = { id: 1, email: "test@test.com" }
 
     // Mock the findOne method to return a user
@@ -141,7 +145,7 @@ describe("UserController", () => {
     const fullUser = await UserController.getUser(mockUser.email)
 
     expect(database.User.findOne).toHaveBeenCalledWith({ where: { email: mockUser.email } })
-    expect(database.Score.findOne).toHaveBeenCalledWith({ where: { userId: mockUser.id } })
+    expect(database.Score.findOne).toHaveBeenCalledWith({ where: { userId: mockUser.id, day: date } })
     expect(fullUser).toBeNull()
   })
 
@@ -157,5 +161,22 @@ describe("UserController", () => {
 
     expect(result).toBeNull()
     expect(consoleSpy).toHaveBeenCalled()
+  })
+
+  it("should return score when user has a score from today", async () => {
+    const date = new Date()
+    date.setUTCHours(0, 0, 0, 0)
+    const mockUser = { id: 1, email: "test@test.com", streak: 1 }
+    const mockScore = { userId: 1, score: 2, day: date }
+    const expectedFullUser = { user: mockUser, scores: mockScore }
+
+    ;(database.User.findOne as jest.Mock).mockResolvedValue(mockUser)
+    ;(database.Score.findOne as jest.Mock).mockResolvedValue(mockScore)
+
+    const fullUser = await UserController.getUser(mockUser.email)
+
+    expect(database.User.findOne).toHaveBeenCalledWith({ where: { email: mockUser.email } })
+    expect(database.Score.findOne).toHaveBeenCalledWith({ where: { userId: mockUser.id, day: date } })
+    expect(fullUser).toEqual(expectedFullUser)
   })
 })

--- a/server/src/controllers/__tests__/user.spec.ts
+++ b/server/src/controllers/__tests__/user.spec.ts
@@ -71,10 +71,10 @@ describe("UserController", () => {
 
     ;(database.User.findOrCreate as jest.Mock).mockResolvedValue(mockUser)
 
-    const fullUser = await UserController.createUser("test@test.com")
+    const user = await UserController.createUser("test@test.com")
 
     expect(database.User.findOrCreate).toHaveBeenCalledWith({ where: { email: "test@test.com" } })
-    expect(fullUser).toEqual(expectedUser)
+    expect(user).toEqual(expectedUser)
   })
 
   it("should not create a user because they already exist", async () => {
@@ -107,7 +107,7 @@ describe("UserController", () => {
     const date = new Date()
     date.setUTCHours(0, 0, 0, 0)
     const mockUser = { id: 1, email: "test@test.com", streak: 1 }
-    const mockScore = { userId: 1, score: 2, day: date }
+    const mockScore = { id: 1, userId: 1, score: 2, day: date }
     const expectedFullUser = { user: mockUser, scores: mockScore }
 
     ;(database.User.findOne as jest.Mock).mockResolvedValue(mockUser)
@@ -167,7 +167,7 @@ describe("UserController", () => {
     const date = new Date()
     date.setUTCHours(0, 0, 0, 0)
     const mockUser = { id: 1, email: "test@test.com", streak: 1 }
-    const mockScore = { userId: 1, score: 2, day: date }
+    const mockScore = { id: 1, userId: 1, score: 2, day: date }
     const expectedFullUser = { user: mockUser, scores: mockScore }
 
     ;(database.User.findOne as jest.Mock).mockResolvedValue(mockUser)

--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -13,7 +13,7 @@ export default class UserController {
     }
   }
 
-  static async createUser(email: User["email"]): Promise<FullUser | null> {
+  static async createUser(email: User["email"]): Promise<User | null> {
     try {
       // Check if user exists, otherwise create them
       const createdUser: [User, boolean] = await db.User.findOrCreate({ where: { email } })
@@ -22,12 +22,7 @@ export default class UserController {
         throw Error("User already exists")
       }
 
-      const userScore: [Score, boolean] = await db.Score.findOrCreate({ where: { userId: createdUser[0].id } })
-
-      return {
-        user: createdUser[0],
-        scores: userScore[0],
-      }
+      return createdUser[0]
     } catch (e) {
       console.error(e)
       return null
@@ -42,7 +37,9 @@ export default class UserController {
         throw Error("User does not exist")
       }
 
-      const scores: Score | null = await db.Score.findOne({ where: { userId: retrievedUser.id } })
+      const date = new Date()
+      date.setUTCHours(0, 0, 0, 0)
+      const scores: Score | null = await db.Score.findOne({ where: { userId: retrievedUser.id, day: date } })
 
       if (!scores) {
         throw Error(`Score does not exist for user ${retrievedUser.id}`)

--- a/server/src/models/score.ts
+++ b/server/src/models/score.ts
@@ -1,27 +1,23 @@
-import { Table, Model, Column, DataType, ForeignKey, BelongsTo } from "sequelize-typescript"
+import { Table, Model, Column, DataType, ForeignKey, BelongsTo, AllowNull, Index } from "sequelize-typescript"
 import { User } from "./user"
 
 @Table({
   tableName: "Scores",
 })
 export class Score extends Model<Score> {
+  @BelongsTo(() => User)
+  user!: User
+
   @ForeignKey(() => User)
   @Column
   userId!: number
 
-  @BelongsTo(() => User)
-  user!: User
+  @AllowNull(false)
+  @Index("score-day-index")
+  @Column(DataType.DATE)
+  day!: Date
 
-  @Column({
-    type: DataType.INTEGER,
-    defaultValue: 0,
-  })
-  streak?: number
-
-  @Column({
-    type: DataType.INTEGER,
-    allowNull: false,
-    defaultValue: 0,
-  })
-  total?: number
+  @AllowNull(false)
+  @Column(DataType.INTEGER)
+  score!: number
 }

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,14 +1,18 @@
-import { Table, Model, Column, DataType, Index, HasOne } from "sequelize-typescript"
+import { Table, Model, Column, DataType, Index, HasMany, Default } from "sequelize-typescript"
 import { Score } from "./score"
 
 @Table({
   tableName: "Users",
 })
 export class User extends Model<User> {
-  @HasOne(() => Score, { foreignKey: "userId" })
-  score!: Score
-
   @Index("email-index")
   @Column(DataType.STRING)
   email!: string
+
+  @Default(0)
+  @Column(DataType.INTEGER)
+  streak!: number
+
+  @HasMany(() => Score)
+  scores!: Score[]
 }

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -12,14 +12,13 @@ userRouter.post("/", async (req, res) => {
     if (userExists) {
       const fullUser: FullUser | null = await UserController.getUser(user.email)
       console.log(fullUser?.user.email)
-      console.log(fullUser?.scores.streak)
-      console.log(fullUser?.scores.total)
+      console.log(fullUser?.user.streak)
+      console.log(fullUser?.scores.score)
       res.status(200).send(fullUser)
     } else {
-      const newUser: FullUser | null = await UserController.createUser(user.email)
-      console.log(newUser?.user.email)
-      console.log(newUser?.scores.streak)
-      console.log(newUser?.scores.total)
+      const newUser: User | null = await UserController.createUser(user.email)
+      console.log(newUser?.email)
+      console.log(newUser?.streak)
       res.status(200).send(newUser)
     }
   } catch (e) {


### PR DESCRIPTION
## Description
The goal of this ticket is to create a new relationship between a user and their scores

The user table will now only hold the email and streak

The scores table will now hold every score for every use and all contain a foreign key pointing back to the user

## Motivation and Context
This will allow holding records of users' statistics over many days

Similar to this:

![Screenshot 2024-04-23 142511](https://github.com/zdigness/puttdle/assets/60762808/daff86f5-766b-43d3-b1eb-dc86cfb94de9)

The next step of this update would be updating the streak based on whether the user completed yesterday's map

We also need to send the appropriate data to the FE like the number of scores in 2, 3, etc.

## How Has This Been Tested?
Updated user.spec.ts to the updated tables
Tested creation of user that doesn't exist + simulated adding a score to the user in postman/pgadmin

## Artifacts (if appropriate):


https://github.com/zdigness/puttdle/assets/60762808/9cae443a-ecb6-4c69-a4af-b19f9952ef90

