### PR TITLE
[TASK] Correct REST API URI Naming Convention

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
   }
 
   function handleLoginSuccess(response: any) {
-    fetch("http://localhost:3000/api/google-login", {
+    fetch("http://localhost:3000/api/v1/users/google-login", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6,7 +6,7 @@ const appRouter = Router()
 
 const appRoutes = [
   {
-    path: "/google-login",
+    path: "/users",
     router: userRouter,
   },
   {

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -5,7 +5,7 @@ import UserController from "../controllers/user"
 
 const userRouter = Router()
 
-userRouter.post("/", async (req, res) => {
+userRouter.post("/google-login", async (req, res) => {
   const user: User = req.body
   try {
     const userExists: User | null = await UserController.checkUser(user?.email)


### PR DESCRIPTION
## Ticket
[[BE] Update Users API Route](https://trello.com/c/9iFVgkld)

## Description
We've updated the route `/api/v1/google-login` to `/api/v1/users/google-login`. 

## Motivation and Context
[Doc](https://restfulapi.net/resource-naming/)

RESTful URI should refer to a resource that is a thing (noun) instead of referring to an action (verb) because nouns have properties that verbs do not have – similarly, resources have attributes. Some examples of a resource are:

* Users of the system
* User Accounts
* Network Devices etc.

and their resource URIs can be designed as below:
```
/device-management/managed-devices 
/device-management/managed-devices/{device-id} 
/user-management/users
/user-management/users/{id}
```

## How Has This Been Tested?
1. Go to root dir
2. `docker-compose up`
3. Wait for resources to spin up
4. Open Postman
5. POST request on `http://localhost:3000/api/v1/users/google-login`
6. See success

## Artifacts (if appropriate):

https://github.com/zdigness/puttdle/assets/23369330/8aa76753-9e18-491a-a93c-06b98dfd2bcf

